### PR TITLE
Added skip parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>io.magentys</groupId>
 	<artifactId>donut-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>0.0.4-SNAPSHOT</version>
+	<version>0.0.5-SNAPSHOT</version>
 	<name>Donut Maven Plugin</name>
 	<url>http://maven.apache.org</url>
 


### PR DESCRIPTION
If you want for any reason to skip generation of reports from the maven plugin configuration, this addition of a <skip>true</skip> plugin configuration parameter allows you to control that from your project pom.

An example of use might be
<skip>${maven.test.skip}</skip>
